### PR TITLE
Fix two crashes in TouchImageView.java

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -859,6 +859,11 @@ public class TouchImageView extends ImageView {
     	
     	@Override
         public boolean onTouch(View v, MotionEvent event) {
+            if (getDrawable() == null) {
+                setState(State.NONE);
+                return false;
+            }
+            mScaleDetector.onTouchEvent(event);
             mScaleDetector.onTouchEvent(event);
             mGestureDetector.onTouchEvent(event);
             PointF curr = new PointF(event.getX(), event.getY());
@@ -1022,6 +1027,10 @@ public class TouchImageView extends ImageView {
 
 		@Override
 		public void run() {
+			if (getDrawable() == null) {
+				setState(State.NONE);
+				return;
+			}
 			float t = interpolate();
 			double deltaScale = calculateDeltaScale(t);
 			scaleImage(deltaScale, bitmapX, bitmapY, stretchImageToSuper);


### PR DESCRIPTION
If the drawable is set to null during a double-tap zoom or other interpolated event, we can get crashes. This can happen if, for example, Glide is used to load a new image into the TouchImageView in the middle of a zoom. This change fixes crashes that come inside the functions the new if() statements are guarding, both of which I've experienced.

Note that different parts of the file appear to be indented differently: the first part of my commit is in a section that uses spaces, and the second is in a section that uses tabs. That's why the two parts of my commit are indented visibly differently.