### PR TITLE
Makes image-switching example activities retain selected image

### DIFF
--- a/app/src/main/java/com/ortiz/touchdemo/ChangeSizeExampleActivity.java
+++ b/app/src/main/java/com/ortiz/touchdemo/ChangeSizeExampleActivity.java
@@ -105,7 +105,7 @@ public class ChangeSizeExampleActivity extends Activity {
             resizeAdjuster.setIndex((Button) findViewById(R.id.resize), savedInstanceState.getInt("resizeAdjusterIndex"));
             rotateAdjuster.setIndex((Button) findViewById(R.id.rotate), savedInstanceState.getInt("rotateAdjusterIndex"));
             imageIndex = savedInstanceState.getInt("imageIndex");
-            // We don't need to call setImageResource, because the TouchImageView remembers its resource.
+            image.setImageResource(images[imageIndex]);
         }
 
         image.post(new Runnable() {

--- a/app/src/main/java/com/ortiz/touchdemo/SwitchImageExampleActivity.java
+++ b/app/src/main/java/com/ortiz/touchdemo/SwitchImageExampleActivity.java
@@ -12,33 +12,35 @@ public class SwitchImageExampleActivity extends Activity {
 	
 	private TouchImageView image;
 	private static int[] images = { R.drawable.nature_1, R.drawable.nature_4, R.drawable.nature_6, R.drawable.nature_7, R.drawable.nature_8 };
-	int index;
+	int index = 0;
 	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_switch_image_example);
 		image = (TouchImageView) findViewById(R.id.img);
-		index = 0;
 		//
 		// Set first image
 		//
-		setCurrentImage();
+		if (savedInstanceState != null) {
+			index = savedInstanceState.getInt("index");
+		}
+		image.setImageResource(images[index]);
 		//
 		// Set next image with each button click
 		//
 		image.setOnClickListener(new OnClickListener() {
-			
 			@Override
 			public void onClick(View v) {
-				setCurrentImage();
+				index = (index + 1) % images.length;
+				image.setImageResource(images[index]);
 			}
 		});
 	}
-	
-	private void setCurrentImage() {
-		image.setImageResource(images[index]);
-		index = (++index % images.length);
-	}
 
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		super.onSaveInstanceState(outState);
+		outState.putInt("index", index);
+	}
 }

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -695,7 +695,6 @@ public class TouchImageView extends ImageView {
         if (matrix == null || prevMatrix == null) {
             return;
         }
-        Log.d("TIV", "fitv. ioc: " + isOrientationChange);
 
         if (userSpecifiedMinScale == AUTOMATIC_MIN_ZOOM) {
             setMinZoom(AUTOMATIC_MIN_ZOOM);


### PR DESCRIPTION
Also cleans up a log statement I left in by mistake.