### PR TITLE
Makes it so fitImageToView() is only called once for each layout change.

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -377,6 +377,7 @@ public class TouchImageView extends ImageView {
     public void setMaxZoomRatio(float max) {
         maxScaleMultiplier = max;
         maxScale = minScale * maxScaleMultiplier;
+        superMaxScale = SUPER_MAX_MULTIPLIER * maxScale;
         maxScaleIsSetByMultiplier = true;
     }
 


### PR DESCRIPTION
This gives a minor efficiency improvement, and also fixes unexpected behaviour. I go into detail about that in a big comment in TouchImageView.java.